### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,11 @@
+name: "Continuous Integration"
+
+on:
+  pull_request:
+  push:
+    branches:
+    tags:
+
+jobs:
+  ci:
+    uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+  "extensions": [
+    "openssl"
+  ]
+}


### PR DESCRIPTION
Fixes #2 

Checks will fail until errors identified by unit tests are fixed.